### PR TITLE
add option and prompt for target repo

### DIFF
--- a/cleanup_workflow_runs.sh
+++ b/cleanup_workflow_runs.sh
@@ -8,20 +8,27 @@
 # the list of actions on [dotcms/core](https://github.com/dotCMS/core/actions/)
 
 #TODO: Option to disable workflow when all runs are cleaned up
-#TODO: Update README.md to make sure you run this in the local working directory
-# of the repo you want to delete workflow runs on.
 
+# Define usage helper function 
+usage() {
+    echo "Usage: $0 -w <workflowID> -r <OWNER/REPO>"
+    exit 1
+}
 
 # Get workflow ID we want to cleanup by command arg OR if not provided, by prompt
 if [ $# -eq 0 ]; then
     read -p "Which workflow (Name or ID) do you want to delete all runs? " workflowID
+    read -p "Provide target <OWNER/REPO> to cleanup. " targetRepo  
 else
-    case $1 in
-        -w|--workflow) workflowID="$2"; shift ;;
-        *) echo "Unknown parameter passed: $1"; exit 1 ;;
-    esac
+    while getopts ":w:r:" opt; do
+        case $opt in
+            w) workflowID=$OPTARG ;;
+            r) targetRepo=$OPTARG ;;
+            \?) echo "Invalid option: -$OPTARG" >&2; usage ;;
+            :) echo "Option -$OPTARG requires an argument." >&2; usage ;;
+        esac
+    done
     shift
-    #workflowID=$1
 fi
 
 echo "You provided Workflow ID: $workflowID"
@@ -44,7 +51,7 @@ if [[ "$response" == "yes" || "$response" == "y" ]]; then
     # Add deletion code here when ready to weaponize this script    
     for id in "${runIDs[@]}"; do
         echo "deleting" $id "..."
-        gh run delete $id
+        gh run --repo $targetRepo delete $id
     done
 elif [[ "$response" == "no" || "$response" == "n" ]]; then
     echo "Aborting...  No deletions made"

--- a/cleanup_workflow_runs.sh
+++ b/cleanup_workflow_runs.sh
@@ -47,6 +47,7 @@ echo -e "\nTotal:" ${#runIDs[@]} "\n"
 
 # Prompt the user for confirmation before deleting
 # TODO: add a "quiet" mode that doesn't require interactivity 
+# TODO: move confirmation and delete to a function and wrap with if statement that exits if runIDs[] is empty
 read -p "Are you sure you want to continue? (yes/no): " response
 if [[ "$response" == "yes" || "$response" == "y" ]]; then
     echo "Continuing..."

--- a/cleanup_workflow_runs.sh
+++ b/cleanup_workflow_runs.sh
@@ -19,6 +19,8 @@ usage() {
 if [ $# -eq 0 ]; then
     read -p "Which workflow (Name or ID) do you want to delete all runs? " workflowID
     read -p "Provide target <OWNER/REPO> to cleanup. " targetRepo  
+elif [ -z $workflowID ]; then
+    read -p "Which workflow (Name or ID) do you want to delete all runs? " workflowID
 else
     while getopts ":w:r:" opt; do
         case $opt in


### PR DESCRIPTION
Before this addition the user needed to run the script from the local directory for the repo.  

- This enhancement adds a new flag `-r` that allows the user to provide a target <OWNER/REPO> for the `gh run delete` command.  
  - added a prompt for it as well in the cases where no flags are provided by the user.  
  - In the case that a user provides only the `-r` flag, they will be prompted for just the workflow ID since it's required
- Adds a `usage` function that gets called to help give the user an idea of what's expected when they enter unrecognized flags
